### PR TITLE
Lm improving contacts get all

### DIFF
--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -144,6 +144,16 @@ class ContactsClient(BaseClient):
         list_id: str = "all",
         **options
     ) -> list:
+        contacts_generator = self.get_all_as_generator(extra_properties, limit, list_id, **options)
+        return list(contacts_generator)
+
+    def get_all_as_generator(
+        self,
+        extra_properties: Union[list, str] = None,
+        limit: int = -1,
+        list_id: str = "all",
+        **options
+    ):
         """
         get all contacts in hubspot, fetching additional properties if passed in
         Can't get phone number from a get-all, so we just grab IDs and

--- a/hubspot3/test/test_contacts.py
+++ b/hubspot3/test/test_contacts.py
@@ -177,7 +177,7 @@ class TestContactsClient(object):
             "has-more": False,
             "vid-offset": 204727,
         }
-        get_batch_return = [dict(id=204727 + i) for i in range(30)]
+        get_batch_return = [dict(id=204727)]
         get_batch_mock = Mock(return_value=get_batch_return)
         contacts_client.get_batch = get_batch_mock
         mock_connection.set_response(200, json.dumps(response_body))
@@ -187,10 +187,6 @@ class TestContactsClient(object):
             "GET", "/contacts/v1/lists/all/contacts/all", count=query_limit, vidOffset=0
         )
         assert resp == get_batch_return if not limit else get_batch_return[:limit]
-        get_batch_mock.assert_called_once_with(
-            [contact["vid"] for contact in response_body["contacts"]],
-            extra_properties=extra_properties,
-        )
 
     @pytest.mark.parametrize(
         "extra_properties_given, extra_properties_as_list",


### PR DESCRIPTION
# Problem

We can't get all contacts at once, since there are so many of them.

# Solution

We can get the contacts through a generator. This solution makes a second API call unecessary. A little modification now allow to get history of contacts.