### PR TITLE
Fixing request properties

### DIFF
--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -194,6 +194,7 @@ class ContactsClient(BaseClient):
                     "vidOffset": offset,
                     "property": properties,
                     "propertyMode": property_mode},
+                doseq=True,
                 **options
             )
             contacts = batch["contacts"]


### PR DESCRIPTION
# Problem

The request to the Contacts API wasn't returning all the parameters we needed, because the url was badly formed.

# Solution 

Added `doseq = True`