### PR TITLE
[DATA-613] Hubspot Incremental - Contacts - ETL

### DIFF
--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -293,6 +293,7 @@ class ContactsClient(BaseClient):
                 "property": default_properties,
                 "timeOffset": time_offset,
                 "propertyMode": property_mode}
+                
             batch = self._call(
                 "lists/recently_updated/contacts/recent",
                 method="GET",


### PR DESCRIPTION
# Problema
Os dados extraídos do hubspot não estão trazendo o histórico das alterações dos contatos

# Solução
Alterar a função `get_recently_modified_in_interval` para receber como parâmetro `with_history` e ter a opção de pegar o histórico dos contatos

# teste
Consultando os registros na base percebemos que só temos o ultimo registro de cada contato e não tínhamos o campo `versions`:

| CONTACT\_ID | PROPERTIES |
| :--- | :--- |
| 53665051 | <br/>  {"value": "1682520910.1596023285"}<br/> |
| 53665051 | <br/>  {"value": "1596024691862"}<br/> |


Depois de alterar a função `get_recently_modified_in_interval` conseguimos ter o campo `versions` para manter a estrutura de dados:
``` 
a.properties[0]["hubspot_team_id"]
{'value': '1467428', 'versions': [{'value': '1467428', 'source-type': 'CALCULATED', 'source-id': 'PermissionsUpdater', 'source-label': None, 'updated-by-user-id': None, 'timestamp': 1635165843893, 'selected': False}]}
a.properties[3]["hubspot_team_id"]
{'value': '211603', 'versions': [{'value': '211603', 'source-type': 'CALCULATED', 'source-id': 'PermissionsUpdater', 'source-label': None, 'updated-by-user-id': None, 'timestamp': 1633031855913, 'selected': False}]}
```
