### PR TITLE
[DATA-597] Hubspot Incremental - Engagements

### DIFF
--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -101,7 +101,7 @@ class EngagementsClient(BaseClient):
             yield from engagements
 
     def get_recently_modified(self, start_date: int, end_date: int, **options):
-        """get recently modified engagements"""
+        """Get recently modified engagements."""
         finished = False
         output = []
         query_limit = 100  # Max value according to docs

--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -103,17 +103,17 @@ class EngagementsClient(BaseClient):
     def get_recently_modified(self, start_date: int, end_date: int, **options):
         """Get recently modified engagements."""
         finished = False
-        output = []
+        engagements = []
         query_limit = 100  # Max value according to docs
         offset = 0
 
         def clean_result(engagement_list, start_d, end_d):
-            output = []
+            engagements_in_interval = []
             for eng in engagement_list:
                 eng_update_date = eng["engagement"]["lastUpdated"]
                 if eng_update_date >= start_d and eng_update_date <= end_d:
-                    output.append(eng)
-            return output
+                    engagements_in_interval.append(eng)
+            return engagements_in_interval
 
         while not finished:
             batch = self._call(
@@ -122,9 +122,9 @@ class EngagementsClient(BaseClient):
                 params={"limit": query_limit, "offset": offset, "since": start_date},
                 **options
             )
-            output.extend(batch["results"])
+            engagements.extend(batch["results"])
             finished = not batch["hasMore"]
             offset = batch["offset"]
-            engagements = clean_result(output, start_date, end_date)
+            engagements = clean_result(engagements, start_date, end_date)
 
             yield from engagements

--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -100,7 +100,7 @@ class EngagementsClient(BaseClient):
 
             yield from engagements
 
-    def get_recently_modified(self, since: int, end_date: int, **options):
+    def get_recently_modified(self, start_date: int, end_date: int, **options):
         """get recently modified engagements"""
         finished = False
         output = []

--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -119,11 +119,12 @@ class EngagementsClient(BaseClient):
             batch = self._call(
                 "engagements/recent/modified",
                 method="GET",
-                params={"limit": query_limit, "offset": offset, "since": since},
+                params={"limit": query_limit, "offset": offset, "since": start_date},
                 **options
             )
             output.extend(batch["results"])
             finished = not batch["hasMore"]
             offset = batch["offset"]
+            engagements = clean_result(output, start_date, end_date)
 
-            yield from clean_result(output, since, end_date)
+            yield from engagements

--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -109,10 +109,9 @@ class EngagementsClient(BaseClient):
 
         def clean_result(engagement_list, start_d, end_d):
             output = []
-            v1 = "engagement"
-            v2 = "lastUpdated"
             for eng in engagement_list:
-                if eng[v1][v2] >= start_d and eng[v1][v2] <= end_d:
+                eng_update_date = eng["engagement"]["lastUpdated"]
+                if eng_update_date >= start_d and eng_update_date <= end_d:
                     output.append(eng)
             return output
 

--- a/hubspot3/test/test_engagements.py
+++ b/hubspot3/test/test_engagements.py
@@ -23,7 +23,7 @@ class TestEngagementsClient(object):
         assert client._get_path(subpath) == "engagements/v1/engagements"
 
     @pytest.mark.parametrize(
-        "since, end_date",
+        "start_date, end_date",
         [
             (500, 2000)
         ],
@@ -32,11 +32,11 @@ class TestEngagementsClient(object):
         self,
         engagements_client,
         mock_connection,
-        since,
+        start_date,
         end_date,
     ):
 
-        params = {"since": since}
+        params = {"since": start_date}
 
         response_body = {
             "results": [
@@ -79,7 +79,7 @@ class TestEngagementsClient(object):
         }
 
         mock_connection.set_response(200, json.dumps(response_body))
-        resp = list(engagements_client.get_recently_modified(since=since, end_date=end_date))
+        resp = list(engagements_client.get_recently_modified(start_date, end_date))
 
         mock_connection.assert_num_requests(1)
         mock_connection.assert_has_request(

--- a/hubspot3/test/test_engagements.py
+++ b/hubspot3/test/test_engagements.py
@@ -1,4 +1,4 @@
-"""Testing hubspot3.engagements 
+"""Testing hubspot3.engagements
 
 This file tests the methods in the hubspot3.engagements file
 """
@@ -23,7 +23,8 @@ class TestEngagementsClient(object):
         subpath = "engagements"
         assert client._get_path(subpath) == "engagements/v1/engagements"
 
-    @pytest.mark.parametrize("start_date, end_date", [(500, 2000)],)
+    @pytest.mark.parametrize("start_date, end_date", [(500, 2000)])
+    def test_get_recently_modified(
         self,
         engagements_client,
         mock_connection,

--- a/hubspot3/test/test_engagements.py
+++ b/hubspot3/test/test_engagements.py
@@ -1,0 +1,91 @@
+"""
+testing hubspot3.engagements
+"""
+import json
+from unittest.mock import Mock
+
+from hubspot3 import engagements
+
+import pytest
+
+
+@pytest.fixture
+def engagements_client(mock_connection):
+    client = engagements.EngagementsClient(disable_auth=True)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    return client
+
+
+class TestEngagementsClient(object):
+    def test_get_path(self):
+        client = engagements.EngagementsClient(disable_auth=True)
+        subpath = "engagements"
+        assert client._get_path(subpath) == "engagements/v1/engagements"
+
+    @pytest.mark.parametrize(
+        "since, end_date",
+        [
+            (500, 2000)
+        ],
+    )
+    def test_get_recently_modified(
+        self,
+        engagements_client,
+        mock_connection,
+        since,
+        end_date,
+    ):
+
+        params = {"since": since}
+
+        response_body = {
+            "results": [
+                {
+                    "engagement": {
+                        "id": 420584370,
+                        "portalId": 62515,
+                        "active": True,
+                        "createdAt": 1635476499000,
+                        "lastUpdated": 1000,
+                        "createdBy": 12345,
+                        "modifiedBy": 12345,
+                        "type": "CALL",
+                        "timestamp": 1635476499000
+                    },
+                    "metadata": {
+                        "body": "This was a call",
+                        "disposition": "17b47fee-58de-441e-a44c-c6300d46f273"
+                    }
+                },
+                {
+                    "engagement": {
+                        "id": 420569029,
+                        "portalId": 62515,
+                        "active": True,
+                        "createdAt": 1535476299000,
+                        "lastUpdated": 100,
+                        "createdBy": 12345,
+                        "modifiedBy": 12345,
+                        "type": "NOTE",
+                        "timestamp": 1535476299000
+                    },
+                    "metadata": {
+                        "body": "This is a note"
+                    }
+                }
+            ],
+            "hasMore": False,
+            "offset": 0
+        }
+
+        mock_connection.set_response(200, json.dumps(response_body))
+        resp = list(engagements_client.get_recently_modified(since=since, end_date=end_date))
+
+        mock_connection.assert_num_requests(1)
+        mock_connection.assert_has_request(
+            "GET", "/engagements/v1/engagements/recent/modified", **params
+        )
+
+        assert len(resp) == 1
+        assert "id" in resp[0]["engagement"]
+        assert 420584370 == resp[0]["engagement"]["id"]

--- a/hubspot3/test/test_engagements.py
+++ b/hubspot3/test/test_engagements.py
@@ -1,5 +1,6 @@
-"""
-testing hubspot3.engagements
+"""Testing hubspot3.engagements 
+
+This file tests the methods in the hubspot3.engagements file
 """
 import json
 from unittest.mock import Mock
@@ -22,13 +23,7 @@ class TestEngagementsClient(object):
         subpath = "engagements"
         assert client._get_path(subpath) == "engagements/v1/engagements"
 
-    @pytest.mark.parametrize(
-        "start_date, end_date",
-        [
-            (500, 2000)
-        ],
-    )
-    def test_get_recently_modified(
+    @pytest.mark.parametrize("start_date, end_date", [(500, 2000)],)
         self,
         engagements_client,
         mock_connection,


### PR DESCRIPTION
# Problema
A infraestrutura atual não é escalável e não atende mais as necessidades da empresa. Hoje temos muitos problemas relacionados a como extraímos os dados da API do Husbpot:

Leva muito tempo para baixarmos todos os dados do Hubspot
A API do Hubspot dá muitos problemas e reinicia a importação de todos os dados
Os dois pontos de cima juntos fazem com que demore mais de 8h para atualizar o DW
Com a entrada da integração do SAP é possível que o tempo de carregamento aumente ainda mais.

# Solução
Nessa etapa conseguimos adicionar a função `get_recently_modified` para importar de forma incremental os dados da API do Hubspot, aqui passamos o parâmetro `since` o qual indica a partir de quando vamos a extrair os dados e o parâmetro `end_date` o qual seria a data de execução da função.

# Teste
Neste caso fizemos um teste **extraindo 1 dia de informação** o dia `2021/11/16, 14:01` com um tempo de execução de 4min e 14seg
``` PYTHON
since = int((dt.datetime.now() - timedelta(days=1)).timestamp())*1000
start_time = dt.datetime.now()
cc = connection.engagements.get_recently_modified(since=since,end_date=int(start_time.timestamp())*1000)
cc_list = list(cc)
end_time = dt.datetime.now()
print(f'Duration copy: {end_time - start_time}')
>>>Duration copy: 0:04:14.611884
a=pd.DataFrame(cc_list)

a['timestamp_c'] = a['engagement'].apply(lambda rownew: rownew['lastUpdated'])
dt.datetime.fromtimestamp(int(a.timestamp_c.min())/1000).strftime("%Y/%m/%d, %H:%M:%S")
>>>'2021/11/15, 14:02:17'
dt.datetime.fromtimestamp(int(a.timestamp_c.max())/1000).strftime("%Y/%m/%d, %H:%M:%S")
>>>'2021/11/16, 14:01:06'
```
Podemos observar que as ultimas alterações estão dentro do intervalo das ultimas 24 horas