### PR TITLE
[DATA-639] Hubspot Incremental - Deals - hubspot3

### DIFF
--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -5,7 +5,7 @@ import warnings
 from typing import Union
 from hubspot3.crm_associations import CRMAssociationsClient
 from hubspot3.base import BaseClient
-from hubspot3.utils import prettify, get_log, clean_result
+from hubspot3.utils import clean_result, get_log, prettify
 
 CONTACTS_API_VERSION = "1"
 

--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -5,7 +5,7 @@ import urllib.parse
 from typing import Dict, Union, List
 
 from hubspot3.base import BaseClient
-from hubspot3.utils import get_log, prettify, split_properties
+from hubspot3.utils import get_log, prettify, split_properties, clean_result
 
 DEALS_API_VERSION = "1"
 
@@ -272,7 +272,6 @@ class DealsClient(BaseClient):
             start_date: int,
             end_date: int,
             offset: int = 0,
-            extra_properties: Union[list, str] = None,
             with_history: bool = False,
             query_limit: int = 100,
             **options
@@ -281,67 +280,30 @@ class DealsClient(BaseClient):
         Get recently modified deals.
         :param start_date: Data pull begin time
         :param end_date: Data pull end time
-        :param extra_properties: A list used to extend the properties fetched
 
         :see: https://developers.hubspot.com/docs/methods/deals/get_deals_modified
         """
         finished = False
-        # default properties to fetch
-        properties = [
-            "associations",
-            "dealname",
-            "dealstage",
-            "pipeline",
-            "hubspot_owner_id",
-            "description",
-            "closedate",
-            "amount",
-            "dealtype",
-            "createdate",
-        ]
-
-        if extra_properties:
-            if isinstance(extra_properties, list):
-                properties += extra_properties
-            if isinstance(extra_properties, str):
-                properties.add(extra_properties)
-
-        if with_history:
-            property_name = "propertiesWithHistory"
-        else:
-            property_name = "properties"
-
-        def clean_result(deal_list, start_d, end_d):
-            deals_in_interval = []
-            for deal in deal_list:
-                deal_update_date = int(deal["properties"]["hs_lastmodifieddate"]["value"])
-                if deal_update_date >= start_d and deal_update_date <= end_d:
-                    deals_in_interval.append(deal)
-            return deals_in_interval
-
-        properties_groups = split_properties(properties, property_name=property_name)
 
         while not finished:
             unjoined_deals = []
-            for properties_group in properties_groups:
-                batch = self._call(
-                    "deal/recent/modified",
-                    method="GET",
-                    params={
-                        "since": start_date,
-                        "count": query_limit,
-                        "offset": offset,
-                        "includePropertyVersions": with_history,
-                        property_name: properties_group
-                    },
-                    doseq=True,
-                    **options
-                )
-                unjoined_deals.extend(batch["results"])
+            batch = self._call(
+                "deal/recent/modified",
+                method="GET",
+                params={
+                    "since": start_date,
+                    "count": query_limit,
+                    "offset": offset,
+                    "includePropertyVersions": with_history
+                },
+                doseq=True,
+                **options
+            )
+            unjoined_deals.extend(batch["results"])
 
             finished = not batch["hasMore"]
             offset = batch["offset"]
             deals = self._join_output_properties(unjoined_deals)
-            deals = clean_result(deals, start_date, end_date)
+            deals = clean_result("deals", deals, start_date, end_date)
 
             yield from deals

--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -5,7 +5,7 @@ import urllib.parse
 from typing import Dict, Union, List
 
 from hubspot3.base import BaseClient
-from hubspot3.utils import get_log, prettify, split_properties, clean_result
+from hubspot3.utils import clean_result, get_log, prettify, split_properties
 
 DEALS_API_VERSION = "1"
 

--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -308,12 +308,12 @@ class DealsClient(BaseClient):
             property_name = "properties"
 
         def clean_result(deal_list, start_d, end_d):
-            output = []
+            deals_in_interval = []
             for deal in deal_list:
                 deal_update_date = int(deal["properties"]["hs_lastmodifieddate"]["value"])
                 if deal_update_date >= start_d and deal_update_date <= end_d:
-                    output.append(deal)
-            return output
+                    deals_in_interval.append(deal)
+            return deals_in_interval
 
         properties_groups = split_properties(properties, property_name=property_name)
 

--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -269,8 +269,8 @@ class DealsClient(BaseClient):
 
     def get_recently_modified_in_interval(
             self,
-            start_date: int,  # data pull begin time
-            end_date: int,  # data pull end time
+            start_date: int,
+            end_date: int,
             offset: int = 0,
             extra_properties: Union[list, str] = None,
             with_history: bool = False,
@@ -278,7 +278,11 @@ class DealsClient(BaseClient):
             **options
     ):
         """
-        Return a list of either recently created or recently modified contacts by timestamp
+        Get recently modified deals.
+        :param start_date: Data pull begin time
+        :param end_date: Data pull end time
+        :param extra_properties: A list used to extend the properties fetched
+
         :see: https://developers.hubspot.com/docs/methods/deals/get_deals_modified
         """
         finished = False

--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -2,7 +2,7 @@
 hubspot engagements api
 """
 from hubspot3.base import BaseClient
-from hubspot3.utils import get_log
+from hubspot3.utils import get_log, clean_result
 
 
 ENGAGEMENTS_API_VERSION = "1"
@@ -107,14 +107,6 @@ class EngagementsClient(BaseClient):
         query_limit = 100  # Max value according to docs
         offset = 0
 
-        def clean_result(engagement_list, start_d, end_d):
-            engagements_in_interval = []
-            for eng in engagement_list:
-                eng_update_date = eng["engagement"]["lastUpdated"]
-                if eng_update_date >= start_d and eng_update_date <= end_d:
-                    engagements_in_interval.append(eng)
-            return engagements_in_interval
-
         while not finished:
             batch = self._call(
                 "engagements/recent/modified",
@@ -125,6 +117,6 @@ class EngagementsClient(BaseClient):
             engagements.extend(batch["results"])
             finished = not batch["hasMore"]
             offset = batch["offset"]
-            engagements = clean_result(engagements, start_date, end_date)
+            engagements = clean_result("engagements", engagements, start_date, end_date)
 
             yield from engagements

--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -2,7 +2,7 @@
 hubspot engagements api
 """
 from hubspot3.base import BaseClient
-from hubspot3.utils import get_log, clean_result
+from hubspot3.utils import clean_result, get_log
 
 
 ENGAGEMENTS_API_VERSION = "1"

--- a/hubspot3/test/test_deals.py
+++ b/hubspot3/test/test_deals.py
@@ -4,10 +4,11 @@ This file tests the methods in the hubspot3.deals file
 """
 import json
 from unittest.mock import Mock
+
 import pytest
+from hubspot3 import deals
 from hubspot3.error import HubspotNotFound, HubspotBadRequest
 from hubspot3.test.globals import TEST_KEY
-from hubspot3 import deals
 
 
 deals_client = deals.DealsClient(api_key=TEST_KEY)

--- a/hubspot3/test/test_deals.py
+++ b/hubspot3/test/test_deals.py
@@ -112,56 +112,7 @@ def test_get_recently_modified_in_interval(
                 "portalId": 62515,
                 "dealId": 38818613,
                 "isDeleted": False,
-                "associations": {
-                    "associatedVids": [1572024],
-                    "associatedCompanyIds": [],
-                    "associatedDealIds": []
-                },
                 "properties": {
-                    "pipeline": {
-                        "value": "default",
-                        "timestamp": 1463680280365,
-                        "source": None,
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "pipeline",
-                                "value": "default",
-                                "timestamp": 1463680280365,
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "dealname": {
-                        "value": "SELLERSQ-national",
-                        "timestamp": 1463680280348,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "dealname",
-                                "value": "SELLERSQ-national",
-                                "timestamp": 1463680280348,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "email_address": {
-                        "value": "sateesh@sellersq.com",
-                        "timestamp": 1463680280348,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "email_address",
-                                "value": "sateesh@sellersq.com",
-                                "timestamp": 1463680280348,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
                     "hs_lastmodifieddate": {
                         "value": "30",
                         "timestamp": 30,
@@ -184,56 +135,7 @@ def test_get_recently_modified_in_interval(
                 "portalId": 62515,
                 "dealId": 25922214,
                 "isDeleted": False,
-                "associations": {
-                    "associatedVids": [1571574],
-                    "associatedCompanyIds": [],
-                    "associatedDealIds": []
-                },
                 "properties": {
-                    "pipeline": {
-                        "value": "default",
-                        "timestamp": 1463676642461,
-                        "source": None,
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "pipeline",
-                                "value": "default",
-                                "timestamp": 1463676642461,
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "dealname": {
-                        "value": "sachin16495-national",
-                        "timestamp": 1463676642448,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "dealname",
-                                "value": "sachin16495-national",
-                                "timestamp": 1463676642448,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "email_address": {
-                        "value": "spsachinonspot@gmail.com",
-                        "timestamp": 1463676642448,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "email_address",
-                                "value": "spsachinonspot@gmail.com",
-                                "timestamp": 1463676642448,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
                     "hs_lastmodifieddate": {
                         "value": "10",
                         "timestamp": 10,
@@ -261,3 +163,4 @@ def test_get_recently_modified_in_interval(
         "GET", "/deals/v1/deal/recent/modified", **params
     )
     assert len(modified_deals) == 1
+    assert modified_deals[0]["dealId"] == 38818613

--- a/hubspot3/test/test_deals.py
+++ b/hubspot3/test/test_deals.py
@@ -10,7 +10,7 @@ from hubspot3 import deals
 import json
 from unittest.mock import Mock
 
-DEALS = DealsClient(api_key=TEST_KEY)
+deals_client = deals.DealsClient(api_key=TEST_KEY)
 
 
 @pytest.fixture
@@ -85,7 +85,7 @@ def test_get_recently_modified():
     gets recently modified deals
     :see: https://developers.hubspot.com/docs/methods/deals/get_deals_modified
     """
-    modified_deals = DEALS.get_recently_modified(limit=20)
+    modified_deals = deals_client.get_recently_modified(limit=20)
     # assert modified_deals
     assert len(modified_deals) <= 20
     # assert _is_deal(modified_deals[0])

--- a/hubspot3/test/test_deals.py
+++ b/hubspot3/test/test_deals.py
@@ -1,5 +1,6 @@
 """
-testing hubspot3.deals
+Testing hubspot3.deals
+This file tests the methods in the hubspot3.deals file
 """
 import pytest
 from hubspot3.deals import DealsClient
@@ -84,18 +85,13 @@ def test_get_recently_modified():
     gets recently modified deals
     :see: https://developers.hubspot.com/docs/methods/deals/get_deals_modified
     """
-    modified_deals = DEALS.get_recently_created(limit=20)
+    modified_deals = DEALS.get_recently_modified(limit=20)
     # assert modified_deals
     assert len(modified_deals) <= 20
     # assert _is_deal(modified_deals[0])
 
 
-@pytest.mark.parametrize(
-    "start_date, end_date",
-    [
-        (20, 40)
-    ],
-)
+@pytest.mark.parametrize("start_date, end_date", [(20, 40)])
 def test_get_recently_modified_in_interval(
     deals_client,
     mock_connection,
@@ -103,7 +99,7 @@ def test_get_recently_modified_in_interval(
     end_date,
 ):
     """
-    gets recently modified deals
+    Gets recently modified deals.
     :see: https://developers.hubspot.com/docs/methods/deals/get_deals_modified
     """
     params = {"since": start_date}
@@ -180,95 +176,6 @@ def test_get_recently_modified_in_interval(
                                 "sourceVid": []
                             }
                         ]
-                    },
-                    "num_associated_contacts": {
-                        "value": "1",
-                        "timestamp": 0,
-                        "source": "CALCULATED",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "num_associated_contacts",
-                                "value": "1",
-                                "source": "CALCULATED",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "dealstage": {
-                        "value": "appointmentscheduled",
-                        "timestamp": 1463680280348,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "dealstage",
-                                "value": "appointmentscheduled",
-                                "timestamp": 1463680280348,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "hs_createdate": {
-                        "value": "1463680280357",
-                        "timestamp": 1463680280357,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "hs_createdate",
-                                "value": "1463680280357",
-                                "timestamp": 1463680280357,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "createdate": {
-                        "value": "1463680280357",
-                        "timestamp": 1463680280357,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "createdate",
-                                "value": "1463680280357",
-                                "timestamp": 1463680280357,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "source": {
-                        "value": "Unknown",
-                        "timestamp": 1463680280348,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "source",
-                                "value": "Unknown",
-                                "timestamp": 1463680280348,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "contact_number": {
-                        "value": "919000884201",
-                        "timestamp": 1463680280348,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "contact_number",
-                                "value": "919000884201",
-                                "timestamp": 1463680280348,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
                     }
                 },
                 "imports": []
@@ -338,95 +245,6 @@ def test_get_recently_modified_in_interval(
                                 "value": "1463676642456",
                                 "timestamp": 1463676642456,
                                 "source": "CALCULATED",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "num_associated_contacts": {
-                        "value": "1",
-                        "timestamp": 0,
-                        "source": "CALCULATED",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "num_associated_contacts",
-                                "value": "1",
-                                "source": "CALCULATED",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "dealstage": {
-                        "value": "appointmentscheduled",
-                        "timestamp": 1463676642448,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "dealstage",
-                                "value": "appointmentscheduled",
-                                "timestamp": 1463676642448,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "hs_createdate": {
-                        "value": "1463676642456",
-                        "timestamp": 1463676642456,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "hs_createdate",
-                                "value": "1463676642456",
-                                "timestamp": 1463676642456,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "createdate": {
-                        "value": "1463676642456",
-                        "timestamp": 1463676642456,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "createdate",
-                                "value": "1463676642456",
-                                "timestamp": 1463676642456,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "source": {
-                        "value": "Unknown",
-                        "timestamp": 1463676642448,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "source",
-                                "value": "Unknown",
-                                "timestamp": 1463676642448,
-                                "source": "API",
-                                "sourceVid": []
-                            }
-                        ]
-                    },
-                    "contact_number": {
-                        "value": "919410249255",
-                        "timestamp": 1463676642448,
-                        "source": "API",
-                        "sourceId": None,
-                        "versions": [
-                            {
-                                "name": "contact_number",
-                                "value": "919410249255",
-                                "timestamp": 1463676642448,
-                                "source": "API",
                                 "sourceVid": []
                             }
                         ]

--- a/hubspot3/test/test_deals.py
+++ b/hubspot3/test/test_deals.py
@@ -2,19 +2,19 @@
 Testing hubspot3.deals
 This file tests the methods in the hubspot3.deals file
 """
+import json
+from unittest.mock import Mock
 import pytest
-from hubspot3.deals import DealsClient
 from hubspot3.error import HubspotNotFound, HubspotBadRequest
 from hubspot3.test.globals import TEST_KEY
 from hubspot3 import deals
-import json
-from unittest.mock import Mock
+
 
 deals_client = deals.DealsClient(api_key=TEST_KEY)
 
 
 @pytest.fixture
-def deals_client(mock_connection):
+def mock_deals_client(mock_connection):
     client = deals.DealsClient(disable_auth=True)
     client.options["connection_type"] = Mock(return_value=mock_connection)
     return client
@@ -36,9 +36,9 @@ def test_get_deal():
     :see: https://developers.hubspot.com/docs/methods/deals/get_deal
     """
     with pytest.raises(HubspotNotFound):
-        DEALS.get("-1")
+        deals_client.get("-1")
 
-    deal_check = DEALS.get("852832561")
+    deal_check = deals_client.get("852832561")
     assert _is_deal(deal_check["properties"])
 
 
@@ -48,7 +48,7 @@ def test_create_deal():
     :see: https://developers.hubspot.com/docs/methods/deals/create_deal
     """
     with pytest.raises(HubspotBadRequest):
-        DEALS.create()
+        deals_client.create()
 
 
 def test_delete_deal():
@@ -62,11 +62,11 @@ def test_delete_deal():
             {"value": None, "name": "createdate"},
         ]
     }
-    response_data = DEALS.create(data)
+    response_data = deals_client.create(data)
     deal_id = response_data["dealId"]
-    DEALS.delete(deal_id)
+    deals_client.delete(deal_id)
     with pytest.raises(HubspotNotFound):
-        DEALS.get(deal_id)
+        deals_client.get(deal_id)
 
 
 def test_get_recently_created():
@@ -74,7 +74,7 @@ def test_get_recently_created():
     gets recently created deals
     :see: https://developers.hubspot.com/docs/methods/deals/get_deals_created
     """
-    new_deals = DEALS.get_recently_created(limit=20)
+    new_deals = deals_client.get_recently_created(limit=20)
     # assert new_deals
     assert len(new_deals) <= 20
     # assert _is_deal(new_deals[0])
@@ -93,7 +93,7 @@ def test_get_recently_modified():
 
 @pytest.mark.parametrize("start_date, end_date", [(20, 40)])
 def test_get_recently_modified_in_interval(
-    deals_client,
+    mock_deals_client,
     mock_connection,
     start_date,
     end_date,
@@ -157,7 +157,7 @@ def test_get_recently_modified_in_interval(
         ]
     }
     mock_connection.set_response(200, json.dumps(response_body))
-    modified_deals = list(deals_client.get_recently_modified_in_interval(start_date, end_date))
+    modified_deals = list(mock_deals_client.get_recently_modified_in_interval(start_date, end_date))
     mock_connection.assert_num_requests(1)
     mock_connection.assert_has_request(
         "GET", "/deals/v1/deal/recent/modified", **params

--- a/hubspot3/test/test_deals.py
+++ b/hubspot3/test/test_deals.py
@@ -5,9 +5,19 @@ import pytest
 from hubspot3.deals import DealsClient
 from hubspot3.error import HubspotNotFound, HubspotBadRequest
 from hubspot3.test.globals import TEST_KEY
-
+from hubspot3 import deals
+import json
+from unittest.mock import Mock
 
 DEALS = DealsClient(api_key=TEST_KEY)
+
+
+@pytest.fixture
+def deals_client(mock_connection):
+    client = deals.DealsClient(disable_auth=True)
+    client.options["connection_type"] = Mock(return_value=mock_connection)
+    return client
+
 
 DEFAULT_DEAL_PROPERTIES = ["dealname", "createdate"]
 
@@ -78,3 +88,358 @@ def test_get_recently_modified():
     # assert modified_deals
     assert len(modified_deals) <= 20
     # assert _is_deal(modified_deals[0])
+
+
+@pytest.mark.parametrize(
+    "start_date, end_date",
+    [
+        (20, 40)
+    ],
+)
+def test_get_recently_modified_in_interval(
+    deals_client,
+    mock_connection,
+    start_date,
+    end_date,
+):
+    """
+    gets recently modified deals
+    :see: https://developers.hubspot.com/docs/methods/deals/get_deals_modified
+    """
+    params = {"since": start_date}
+    response_body = {
+        "hasMore": False,
+        "offset": 2,
+        "total": 2477,
+        "results": [
+            {
+                "portalId": 62515,
+                "dealId": 38818613,
+                "isDeleted": False,
+                "associations": {
+                    "associatedVids": [1572024],
+                    "associatedCompanyIds": [],
+                    "associatedDealIds": []
+                },
+                "properties": {
+                    "pipeline": {
+                        "value": "default",
+                        "timestamp": 1463680280365,
+                        "source": None,
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "pipeline",
+                                "value": "default",
+                                "timestamp": 1463680280365,
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "dealname": {
+                        "value": "SELLERSQ-national",
+                        "timestamp": 1463680280348,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "dealname",
+                                "value": "SELLERSQ-national",
+                                "timestamp": 1463680280348,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "email_address": {
+                        "value": "sateesh@sellersq.com",
+                        "timestamp": 1463680280348,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "email_address",
+                                "value": "sateesh@sellersq.com",
+                                "timestamp": 1463680280348,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "hs_lastmodifieddate": {
+                        "value": "30",
+                        "timestamp": 30,
+                        "source": "CALCULATED",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "hs_lastmodifieddate",
+                                "value": "1463680280357",
+                                "timestamp": 1463680280357,
+                                "source": "CALCULATED",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "num_associated_contacts": {
+                        "value": "1",
+                        "timestamp": 0,
+                        "source": "CALCULATED",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "num_associated_contacts",
+                                "value": "1",
+                                "source": "CALCULATED",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "dealstage": {
+                        "value": "appointmentscheduled",
+                        "timestamp": 1463680280348,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "dealstage",
+                                "value": "appointmentscheduled",
+                                "timestamp": 1463680280348,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "hs_createdate": {
+                        "value": "1463680280357",
+                        "timestamp": 1463680280357,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "hs_createdate",
+                                "value": "1463680280357",
+                                "timestamp": 1463680280357,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "createdate": {
+                        "value": "1463680280357",
+                        "timestamp": 1463680280357,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "createdate",
+                                "value": "1463680280357",
+                                "timestamp": 1463680280357,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "source": {
+                        "value": "Unknown",
+                        "timestamp": 1463680280348,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "source",
+                                "value": "Unknown",
+                                "timestamp": 1463680280348,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "contact_number": {
+                        "value": "919000884201",
+                        "timestamp": 1463680280348,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "contact_number",
+                                "value": "919000884201",
+                                "timestamp": 1463680280348,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    }
+                },
+                "imports": []
+            },
+            {
+                "portalId": 62515,
+                "dealId": 25922214,
+                "isDeleted": False,
+                "associations": {
+                    "associatedVids": [1571574],
+                    "associatedCompanyIds": [],
+                    "associatedDealIds": []
+                },
+                "properties": {
+                    "pipeline": {
+                        "value": "default",
+                        "timestamp": 1463676642461,
+                        "source": None,
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "pipeline",
+                                "value": "default",
+                                "timestamp": 1463676642461,
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "dealname": {
+                        "value": "sachin16495-national",
+                        "timestamp": 1463676642448,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "dealname",
+                                "value": "sachin16495-national",
+                                "timestamp": 1463676642448,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "email_address": {
+                        "value": "spsachinonspot@gmail.com",
+                        "timestamp": 1463676642448,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "email_address",
+                                "value": "spsachinonspot@gmail.com",
+                                "timestamp": 1463676642448,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "hs_lastmodifieddate": {
+                        "value": "10",
+                        "timestamp": 10,
+                        "source": "CALCULATED",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "hs_lastmodifieddate",
+                                "value": "1463676642456",
+                                "timestamp": 1463676642456,
+                                "source": "CALCULATED",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "num_associated_contacts": {
+                        "value": "1",
+                        "timestamp": 0,
+                        "source": "CALCULATED",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "num_associated_contacts",
+                                "value": "1",
+                                "source": "CALCULATED",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "dealstage": {
+                        "value": "appointmentscheduled",
+                        "timestamp": 1463676642448,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "dealstage",
+                                "value": "appointmentscheduled",
+                                "timestamp": 1463676642448,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "hs_createdate": {
+                        "value": "1463676642456",
+                        "timestamp": 1463676642456,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "hs_createdate",
+                                "value": "1463676642456",
+                                "timestamp": 1463676642456,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "createdate": {
+                        "value": "1463676642456",
+                        "timestamp": 1463676642456,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "createdate",
+                                "value": "1463676642456",
+                                "timestamp": 1463676642456,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "source": {
+                        "value": "Unknown",
+                        "timestamp": 1463676642448,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "source",
+                                "value": "Unknown",
+                                "timestamp": 1463676642448,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    },
+                    "contact_number": {
+                        "value": "919410249255",
+                        "timestamp": 1463676642448,
+                        "source": "API",
+                        "sourceId": None,
+                        "versions": [
+                            {
+                                "name": "contact_number",
+                                "value": "919410249255",
+                                "timestamp": 1463676642448,
+                                "source": "API",
+                                "sourceVid": []
+                            }
+                        ]
+                    }
+                },
+                "imports": []
+            }
+        ]
+    }
+    mock_connection.set_response(200, json.dumps(response_body))
+    modified_deals = list(deals_client.get_recently_modified_in_interval(start_date, end_date))
+    mock_connection.assert_num_requests(1)
+    mock_connection.assert_has_request(
+        "GET", "/deals/v1/deal/recent/modified", **params
+    )
+    assert len(modified_deals) == 1

--- a/hubspot3/utils.py
+++ b/hubspot3/utils.py
@@ -91,3 +91,22 @@ def split_properties(properties: Set[str],
         properties_groups.append(current_properties_group)
 
     return properties_groups
+
+
+def clean_result(source_name, source_list, start_d, end_d):
+    source_in_interval = []
+
+    def date_format(source_name, item):
+        if source_name == "deals":
+            update_date = int(item["properties"]["hs_lastmodifieddate"]["value"])
+        elif source_name == "engagements":
+            update_date = item["engagement"]["lastUpdated"]
+        elif source_name == "contacts":
+            update_date = item["addedAt"]
+        return update_date
+
+    for item in source_list:
+        update_date = date_format(source_name, item)
+        if update_date >= start_d and update_date <= end_d:
+            source_in_interval.append(item)
+    return source_in_interval


### PR DESCRIPTION
# Problema
A infraestrutura atual não é escalável e não atende mais as necessidades da empresa. Hoje temos muitos problemas relacionados a como extraímos os dados da API do Husbpot:

Leva muito tempo para baixarmos todos os dados do Hubspot
A API do Hubspot dá muitos problemas e reinicia a importação de todos os dados
Os dois pontos de cima juntos fazem com que demore mais de 8h para atualizar o DW
Com a entrada da integração do SAP é possível que o tempo de carregamento aumente ainda mais.

# Solução
Criamos a função `get_recently_modified_in_interval` que é compatível com a nossa infraestrutura atual e recebe os parâmetros: `start_date, end_date, extra_properties e with_history` para pegar a informação dos Deals com a formatação atual num intervalo do tempo

# Teste
Nesse caso testamos obtendo 3 dias de informação o qual demorou 16mins 25 segs:
```PYTHON
>>> start_date = int((dt.datetime.now() - timedelta(days=3)).timestamp())*1000
>>> start_time = dt.datetime.now()
>>> end_date = int(start_time.timestamp())*1000
>>> cc = connection.deals.get_recently_modified_in_interval(extra_properties=properties_label, start_date=start_date, end_date=end_date, with_history=True)
>>> cc_list = list(cc)
>>> end_time = dt.datetime.now()
>>> print(f'Duration copy: {end_time - start_time}')
Duration copy: 0:16:25.948566
>>>
>>> a=pd.DataFrame(cc_list)
>>> a['timestamp_c'] = a["properties"].apply(lambda rownew: rownew["hs_lastmodifieddate"]["value"])
>>> dt.datetime.fromtimestamp(int(a.timestamp_c.min())/1000).strftime("%Y/%m/%d, %H:%M:%S")
'2021/11/22, 12:16:09'
>>> dt.datetime.fromtimestamp(int(a.timestamp_c.max())/1000).strftime("%Y/%m/%d, %H:%M:%S")
'2021/11/25, 12:12:29'
>>> a.shape
(7439, 7)
>>> start_date
1637594046000
>>> end_date 
1637853246000
>>>

```
