### PR TITLE
[DATA-650] verificar a request dos ultimos engagements

### DIFF
--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -121,7 +121,7 @@ class EngagementsClient(BaseClient):
 
             yield from engagements
 
-    def check_request(self, start_date: int):
+    def count_recently_modified_engagements(self, since: int):
         """check limit of request."""
         query_limit = 100  # Max value according to docs
         offset = 0

--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -129,7 +129,7 @@ class EngagementsClient(BaseClient):
         batch = self._call(
             "engagements/recent/modified",
             method="GET",
-            params={"limit": query_limit, "offset": offset, "since": start_date}
+            params={"limit": query_limit, "offset": offset, "since": since}
         )
         total = batch["total"]
         return total

--- a/hubspot3/engagements.py
+++ b/hubspot3/engagements.py
@@ -120,3 +120,16 @@ class EngagementsClient(BaseClient):
             engagements = clean_result("engagements", engagements, start_date, end_date)
 
             yield from engagements
+
+    def check_request(self, start_date: int):
+        """check limit of request."""
+        query_limit = 100  # Max value according to docs
+        offset = 0
+
+        batch = self._call(
+            "engagements/recent/modified",
+            method="GET",
+            params={"limit": query_limit, "offset": offset, "since": start_date}
+        )
+        total = batch["total"]
+        return total


### PR DESCRIPTION
# Problema
Hoje temos uma limitação na request dos engagements de 10000 registros e as vezes alcança o limite num corto intervalo do tempo 

# Solução
Criamos uma função para verificar o total da reques dos últimos engagements

# Teste

>>> start_date = int((dt.datetime.now() - timedelta(hours=8)).timestamp())*1000
>>> start_time = dt.datetime.now()
>>> cc = connection.engagements.check_request(start_date=start_date)   
>>> cc
6697