### PR TITLE
adicionando contagem dos deals

### DIFF
--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -307,3 +307,16 @@ class DealsClient(BaseClient):
             deals = clean_result("deals", deals, start_date, end_date)
 
             yield from deals
+
+    def count_recently_modified_deals(self, start_date: int):
+        """check limit of request."""
+        query_limit = 100  # Max value according to docs
+        offset = 0
+
+        batch = self._call(
+            "deal/recent/modified",
+            method="GET",
+            params={"limit": query_limit, "offset": offset, "since": start_date}
+        )
+        total = batch["total"]
+        return total


### PR DESCRIPTION
# Problema
**O que aconteceu:** a API do hubspot tem uma limitação de 30 dias ou 10.000 registros para os últimos deals modificados o que impede rodar o processo no intervalo de tempo.

**Impactos desse erro:** Não atualiza o DW

# Solução
Rodar automaticamente o histórico quando tem mais de 10.000 registros.

# Teste
![image](https://user-images.githubusercontent.com/90647011/148066389-6e1a7ba1-d16f-4cd8-9782-24fc7b7c1d62.png)
