### PR TITLE
[DATA-817] Pegando histórico de form-submissions

### DIFF
--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -258,6 +258,7 @@ class ContactsClient(BaseClient):
             extra_properties: Union[list, str] = None,
             with_history: bool = False,
             query_limit: int = 100,
+            form_submission_mode: str = "newest"
             **options
     ):
         """
@@ -285,7 +286,8 @@ class ContactsClient(BaseClient):
                 "count": query_limit,
                 "property": default_properties,
                 "timeOffset": time_offset,
-                "propertyMode": property_mode}
+                "propertyMode": property_mode,
+                "formSubmissionMode": form_submission_mode}
 
             batch = self._call(
                 "lists/recently_updated/contacts/recent",

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -258,7 +258,7 @@ class ContactsClient(BaseClient):
             extra_properties: Union[list, str] = None,
             with_history: bool = False,
             query_limit: int = 100,
-            form_submission_mode: str = "newest"
+            form_submission_mode: str = "newest",
             **options
     ):
         """


### PR DESCRIPTION
# Problema

Para construir o histórico de form submissions, precisamos pedir para a API devolver todo o histórico.

# Solução

- Permitindo escolher tipo do histórico de form submissions

# Teste

Com o seguinte código (algumas partes omitidas por questões de segurança):

```python
from hubspot3 import Hubspot3
import datetime as dt
from datetime import timedelta
import pandas as pd

hapikey = "<hubspot_api_key>" # Comentada porque o repo é público

connection = Hubspot3(api_key=hapikey)
start_date = int((dt.datetime.now() - timedelta(hours=1)).timestamp())*1000
end_time = int(dt.datetime.now().timestamp())*1000

cc = connection.contacts.get_recently_modified_in_interval(start_date=start_date, 
                                                           end_date=end_time,
                                                           with_history=True,
                                                           form_submission_mode='all')

cc_list = list(cc)
example_contact = pd.DataFrame(cc_list)

print(len(example_contact["form-submissions"][0]))
```

O que indica que pegamos todas as 16 submissões que esse contato realizou (confirmado com a request individual para esse contato).
