### PR TITLE
[DATA-1243] Usando split_properties

### DIFF
--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -311,7 +311,7 @@ class ContactsClient(BaseClient):
             for group in properties_groups:
                 params = {
                     "count": query_limit,
-                    "property": default_properties,
+                    "property": group,
                     "timeOffset": time_offset,
                     "propertyMode": property_mode,
                     "formSubmissionMode": form_submission_mode

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -2,7 +2,7 @@
 hubspot contacts api
 """
 import warnings
-from typing import Union
+from typing import Union, List
 from hubspot3.crm_associations import CRMAssociationsClient
 from hubspot3.base import BaseClient
 from hubspot3.utils import clean_result, get_log, prettify, split_properties

--- a/hubspot3/contacts.py
+++ b/hubspot3/contacts.py
@@ -142,7 +142,7 @@ class ContactsClient(BaseClient):
         Join request properties to show only one object per contactId
         This will change the first object for each contactId
         """
-        joined_contact_dict = {}
+        joined_contacts_dict = {}
         for contact in contacts:
             # Converting the ID to str to make it compatible with API
             contact_id = str(contact["vid"])

--- a/hubspot3/deals.py
+++ b/hubspot3/deals.py
@@ -82,8 +82,8 @@ class DealsClient(BaseClient):
 
     def _join_output_properties(self, deals: List[dict]) -> dict:
         """
-        Join request properties to show only one object per ticketId
-        This will change the first object for each ticketId
+        Join request properties to show only one object per dealId
+        This will change the first object for each dealId
         """
         joined_deals_dict = {}
         for deal in deals:


### PR DESCRIPTION
# Problema

Hoje, se pedirmos todas as propriedades dos contatos, o Hubspot devolve o erro 414 (Request Too Long).

# Solução

Usar função split_properties pra fazer requests dentro do limite de caracteres.


- Usando split properties para o get_all
- Usando split properties no incremental e definindo função de join
- Arrumando docstring
- Adicionando tipo
- Declarando variável
- Usando split_properties

# Testes

Para os testes, estou usando todas as propriedades. A ideia é ver se alguma que não estamos tratando hoje vem nesse pull de dados.

![Captura de tela de 2022-08-01 18-57-45](https://user-images.githubusercontent.com/12700393/182253232-da862a33-542e-49d7-9da5-1d8b860e5f27.png)

## 1. No incremental

![Captura de tela de 2022-08-01 18-59-10](https://user-images.githubusercontent.com/12700393/182253255-146e03c8-32d1-4cee-97b2-1c8730747238.png)

## 2. No get_all 

![Captura de tela de 2022-08-01 18-59-19](https://user-images.githubusercontent.com/12700393/182253277-dd1d14a2-cd0e-42b7-a243-d573d02715fa.png)
